### PR TITLE
Refactor dwell2 search

### DIFF
--- a/run_tank_characterization.py
+++ b/run_tank_characterization.py
@@ -1,7 +1,6 @@
 import sys
 from os.path import expanduser
 from multiprocessing import Process, Manager
-import h5py
 import logging
 
 logging.getLogger("xija").setLevel(logging.WARNING)
@@ -11,101 +10,112 @@ sys.path.append(home + '/AXAFLIB/timbre/')
 from timbre import *
 
 
-utf8_type_20 = h5py.string_dtype('utf-8', 20)
-utf8_type_8 = h5py.string_dtype('utf-8', 8)
+def get_full_dtype(state_pair_dtype_dict):
+    """ Add Numpy data types for parameters specific to model to the boilerplate array data types.
 
-results_dtype = [('msid', utf8_type_20),
-                 ('date', utf8_type_8),
-                 ('datesecs', np.float64),
-                 ('limit', np.float64),
-                 ('t_dwell1', np.float64),
-                 ('t_dwell2', np.float64),
-                 ('min_temp', np.float64),
-                 ('mean_temp', np.float64),
-                 ('max_temp', np.float64),
-                 ('min_pseudo', np.float64),
-                 ('mean_pseudo', np.float64),
-                 ('max_pseudo', np.float64),
-                 ('converged', np.bool),
-                 ('unconverged_hot', np.bool),
-                 ('unconverged_cold', np.bool),
-                 ('hotter_state', np.int8),
-                 ('colder_state', np.int8)]
+    :param state_pair_dtype_dict: Dictionary of Numpy data types
+    :return: List of Numpy data types, including items specific to current model (e.g. pitch, roll, ccd_count, etc.)
+
+    Example input:
+        state_pair_dtype_dict = {'pitch': np.float64, 'roll': np.float64}
+
+    """
+
+    full_results_dtype = [('msid', utf8_type_20),
+                          ('date', utf8_type_8),
+                          ('datesecs', np.float64),
+                          ('limit', np.float64),
+                          ('t_dwell1', np.float64),
+                          ('t_dwell2', np.float64),
+                          ('min_temp', np.float64),
+                          ('mean_temp', np.float64),
+                          ('max_temp', np.float64),
+                          ('min_pseudo', np.float64),
+                          ('mean_pseudo', np.float64),
+                          ('max_pseudo', np.float64),
+                          ('converged', np.bool),
+                          ('unconverged_hot', np.bool),
+                          ('unconverged_cold', np.bool),
+                          ('hotter_state', np.int8),
+                          ('colder_state', np.int8)]
+
+    # There are separate items for the first and second dwells, so for each item specific to the current model, add
+    # corresponding first and second dwell dtypes.
+    for param, state in state_pair_dtype_dict.items():
+        full_results_dtype.append((param + '1', state))
+
+    for param, state in state_pair_dtype_dict.items():
+        full_results_dtype.append((param + '2', state))
+
+    return full_results_dtype
 
 
 def get_local_model(filename):
     """ Load parameters for a single Xija model.
+
+    :param filename: File path to local model specification file
+    :return: Model spec as a dictionary, md5 hash of model spec
+
     """
 
     with open(filename) as fid:  # 'aca/aca_spec.json', 'rb') as fid:
         f = fid.read()
 
-    md5_hash = md5(f.encode('utf-8')).hexdigest()
-
-    return json.loads(f), md5_hash
+    return json.loads(f), md5(f.encode('utf-8')).hexdigest()
 
 
-def save_results_to_hdf5(filename, results):
-    ind = np.argsort(results, order=['datesecs', 'pitch1', 'pitch2', 't_dwell1', 't_dwell2'])
-    results = results[ind]
+def save_results_to_hdf5(filename, results_array):
+    """ Save Timbre results to an HDF5 file.
+
+    Due to some compatibility issues with some string formats in HDF5 files, this may be deprecated in the future.
+
+    :param filename: File name for HDF5 output file
+    :param results_array: Numpy array of results
+
+    """
+
+    ind = np.argsort(results_array, order=['datesecs', 'pitch1', 'pitch2', 't_dwell1', 't_dwell2'])
+    results_array = results_array[ind]
     with h5py.File(filename, 'w') as f:
-        dset = f.create_dataset('results', (np.shape(results)), dtype=results_dtype)
+        dset = f.create_dataset('results', (np.shape(results_array)), dtype=results_dtype)
         dset[...] = results
         f.flush()
 
 
-model_spec, model_hash = get_local_model('/Users/mdahmer/WIP/xija_model_updates/pftank2t/chandra_models/chandra_models/xija/pftank2t/pftank2t_spec.json')
-msid = 'pftank2t'
-datestamp = DateTime().caldate[:9]
-init = {'pftank2t': -8, 'pf0tank2t': -8, 'eclipse': False}
-state_pair_dtype = {'pitch': np.float64, 'roll': np.float64, 'cossrbx_on': np.bool}
+def run_cases(msid_name, model_specification, model_md5, initial_params, dwell1_sets, binary_schedule_state_pairs,
+              state_pair_numpy_dtype, date_and_limit_cases):
+    """
 
-for key, value in state_pair_dtype.items():
-    results_dtype.append((key + '1', value))
-for key, value in state_pair_dtype.items():
-    results_dtype.append((key + '2', value))
+    :param msid_name: Mnemonic name
+    :param model_specification: Dictionary containing model specification
+    :param model_md5: Model MD5 hash
+    :param initial_params: Dictionary of initial parameters for the current model
+    :param dwell1_sets: Two dimensional iterable of initial dwell times
+    :param binary_schedule_state_pairs: Dictionary of first and second states, excluding dates and limits
+    :param state_pair_numpy_dtype: List of name + Numpy data type pairs for each simulation, used to format Timbre
+            results
+    :param date_and_limit_cases: Dictionary of dates and limits, where the keys are dates, and the values for each key
+            are a list of limits to run for the date
 
-if __name__ == "__main__":
-
-    sets = [10000, 20000, 30000, 40000]
-    pitch_vals = list(range(45, 180, 5))
-    roll_vals = [-10, 0, 10]
-
-    cases = {'2020:274:00:00:00': timbre.f_to_c([105.0, 110.0]),
-             '2021:001:00:00:00': timbre.f_to_c([105.0, 110.0, 115.0]),
-             '2021:091:00:00:00': timbre.f_to_c([105.0, 110.0, 115.0]),
-             '2021:182:00:00:00': timbre.f_to_c([110.0, 115.0, 120.0]),
-             '2021:274:00:00:00': timbre.f_to_c([110.0, 115.0, 120.0]),
-             '2022:001:00:00:00': timbre.f_to_c([110.0, 115.0, 120.0])}
-
-    state_pairs = [({'pitch': pn1, 'roll': rn1, 'cossrbx_on': ssr}, {'pitch': pn2, 'roll': rn2, 'cossrbx_on': ssr})
-                   for pn1 in pitch_vals
-                   for pn2 in pitch_vals
-                   for rn1 in roll_vals
-                   for rn2 in roll_vals
-                   for ssr in [True, False]]
-
-    print(f'Starting Timbre simulations on {DateTime().caldate}')
-
-    # ------------------------------------------------------------------------------------------------------------------
-
-    run_sets = [[10000, 20000, 30000, 40000], [50000, 60000, 70000, 80000], [90000, 100000] ]
+    """
 
     k = 0
-    for date, limits in cases.items():
-        datestr = DateTime(date).date[:4] + DateTime(date).date[5:8]
+    for full_date_str, limits in date_and_limit_cases.items():
+        date_str = DateTime(full_date_str).date[:4] + DateTime(full_date_str).date[5:8]
 
-        for sets in run_sets:
+        for sets in dwell1_sets:
 
-            for limit in limits:
+            for limit_celsius in limits:
                 k = k + 1
 
                 manager = Manager()
                 return_list = manager.list()
+
                 jobs = []
 
-                for s in sets:
-                    args = (msid, model_spec, init, limit, date, s, state_pairs, state_pair_dtype)
+                for dwell1_secs in sets:
+                    args = (msid_name, model_specification, initial_params, limit_celsius, date_str, dwell1_secs,
+                            binary_schedule_state_pairs, state_pair_numpy_dtype)
                     kwargs = {'max_dwell': 200000, 'shared_data': return_list}
                     jobs.append(Process(target=run_state_pairs, args=args, kwargs=kwargs))
 
@@ -115,11 +125,41 @@ if __name__ == "__main__":
                 for j in jobs:
                     j.join()
 
-                results = np.hstack(return_list)
-                filename = f'pftank2t_{datestamp}_5_deg_resolution_{datestr}_save_{k}.h5'
-                save_results_to_hdf5(filename, results)
+                results_array = np.hstack(return_list)
+                filename = f'{msid_name}_{model_md5}_{datestamp}_{date_str}_save_{k}.h5'
+                save_results_to_hdf5(filename, results_array)
 
                 print('Completed {}, limit={} on {}'.format(date, limit, DateTime().caldate))
 
+
+if __name__ == "__main__":
+
+    model_spec, model_hash = get_local_model('/Users/mdahmer/AXAFLIB/chandra_models/xija/pftank2t/pftank2t_spec.json')
+    msid = 'pftank2t'
+    datestamp = DateTime().caldate[:9]
+    init = {'pftank2t': -8, 'pf0tank2t': -8, 'eclipse': False}
+    state_pair_dtype = {'pitch': np.float64, 'roll': np.float64}
+    results_dtype = get_full_dtype(state_pair_dtype)
+
+    pitch_vals = list(range(45, 181, 5))
+    roll_vals = [-10, 0, 10]
+
+    cases = {'2021:001:00:00:00': timbre.f_to_c([105.0, 110.0, 115.0]),
+             '2021:091:00:00:00': timbre.f_to_c([105.0, 110.0, 115.0]),
+             '2021:182:00:00:00': timbre.f_to_c([110.0, 115.0, 120.0]),
+             '2021:274:00:00:00': timbre.f_to_c([110.0, 115.0, 120.0]),
+             '2022:001:00:00:00': timbre.f_to_c([110.0, 115.0, 120.0])}
+
+    state_pairs = [({'pitch': pn1, 'roll': rn1}, {'pitch': pn2, 'roll': rn2})
+                   for pn1 in pitch_vals
+                   for pn2 in pitch_vals
+                   for rn1 in roll_vals
+                   for rn2 in roll_vals]
+
+    run_sets = [[10000, 20000, 30000, 40000], [50000, 60000, 70000, 80000], [90000, 100000]]
+
+    print(f'Starting Timbre simulations on {DateTime().caldate}')
+
+    run_cases(msid, model_spec, model_hash, init, run_sets, state_pairs, state_pair_dtype, cases)
 
     print(f'Completed all Timbre simulations on {DateTime().caldate}')

--- a/run_tank_characterization.py
+++ b/run_tank_characterization.py
@@ -78,7 +78,7 @@ def save_results_to_hdf5(filename, results_array):
     results_array = results_array[ind]
     with h5py.File(filename, 'w') as f:
         dset = f.create_dataset('results', (np.shape(results_array)), dtype=results_dtype)
-        dset[...] = results
+        dset[...] = results_array
         f.flush()
 
 
@@ -129,12 +129,12 @@ def run_cases(msid_name, model_specification, model_md5, initial_params, dwell1_
                 filename = f'{msid_name}_{model_md5}_{datestamp}_{date_str}_save_{k}.h5'
                 save_results_to_hdf5(filename, results_array)
 
-                print('Completed {}, limit={} on {}'.format(date, limit, DateTime().caldate))
+                print(f'Completed {date_str}, limit={limit_celsius}, dwell1 times={sets} on {DateTime().caldate}')
 
 
 if __name__ == "__main__":
 
-    model_spec, model_hash = get_local_model('/Users/mdahmer/AXAFLIB/chandra_models/xija/pftank2t/pftank2t_spec.json')
+    model_spec, model_hash = get_local_model('/Users/mdahmer/AXAFLIB/chandra_models/chandra_models/xija/pftank2t/pftank2t_spec.json')
     msid = 'pftank2t'
     datestamp = DateTime().caldate[:9]
     init = {'pftank2t': -8, 'pf0tank2t': -8, 'eclipse': False}
@@ -160,6 +160,6 @@ if __name__ == "__main__":
 
     print(f'Starting Timbre simulations on {DateTime().caldate}')
 
-    run_cases(msid, model_spec, model_hash, init, run_sets, state_pairs, state_pair_dtype, cases)
+    run_cases(msid, model_spec, model_hash, init, run_sets, state_pairs, results_dtype, cases)
 
     print(f'Completed all Timbre simulations on {DateTime().caldate}')

--- a/timbre/timbre.py
+++ b/timbre/timbre.py
@@ -11,8 +11,6 @@ from Chandra.Time import DateTime
 import xija
 
 import h5py
-utf8_type_20 = h5py.string_dtype('utf-8', 20)
-utf8_type_8 = h5py.string_dtype('utf-8', 8)
 
 pseudo_names = dict(
     zip(['aacccdpt', 'pftank2t', '1dpamzt', '4rt700t', '1deamzt'], ['aca0', 'pf0tank2t', 'dpa0', 'oba0', 'dea0']))
@@ -665,15 +663,19 @@ def run_state_pairs(msid, model_spec, init, limit, date, dwell_1_duration, state
 
         results.append(tuple(row))
 
-    results = np.array(results, dtype=state_pair_dtype)
+    results_array = np.array(results, dtype=state_pair_dtype)
 
     if shared_data is not None:
-        shared_data.append(results)
+        shared_data.append(results_array)
     else:
-        return results
+        return results_array
 
 
 if __name__ == '__main__':
+
+    utf8_type_20 = h5py.string_dtype('utf-8', 20)
+    utf8_type_8 = h5py.string_dtype('utf-8', 8)
+
     results_dtype = [('msid', utf8_type_20),
                      ('date', utf8_type_8),
                      ('datesecs', np.float64),

--- a/timbre/timbre.py
+++ b/timbre/timbre.py
@@ -333,7 +333,7 @@ def create_opt_fun(datesecs, dwell1_state, dwell2_state, t_dwell1, msid, model_s
 
 
 def find_second_dwell(date, dwell1_state, dwell2_state, t_dwell1, msid, limit, model_spec, init, limit_type='max',
-                      duration=2592000, t_backoff=1725000, n_dwells=10., max_dwell=None, pseudo=None, debug=False):
+                      duration=2592000, t_backoff=1725000, n_dwells=10., max_dwell=None, pseudo=None):
     """ Determine the required dwell time at pitch2 to balance a given fixed dwell time at pitch1, if any exists.
 
     Args:
@@ -354,17 +354,18 @@ def find_second_dwell(date, dwell1_state, dwell2_state, t_dwell1, msid, limit, m
         max_dwell (float): Maximum duration for second dwell, can be tuned to provide better results
         pseudo (:obj:`str`, optional): Name of one or more pseudo MSIDs used in the model, if any, only necessary if one
             wishes to retrieve model results for this pseudo node, if it exists - To be implemented at a later date
-        debug (bool): Adds the output of the final dwell 2 time refinement step to the returned data
 
     Returns:
         dict: Dictionary of results information
-        ndarray: If debug==True, Numpy array of maximum, mean, and minimum temperatures for each simulation generated,
-            within the last `t_backoff` duration (e.g. the last two thirds of `duration`) for the final refinement step.
 
     """
 
     datesecs = DateTime(date).secs
-    limit_type = limit_type.lower()
+
+    if 'max' in limit_type.lower():
+        limit_type = 'max'
+    else:
+        limit_type = 'min'
 
     if max_dwell is None:
         # This ensures three "cycles" of the two dwell states, within the portion of the schedule used for evaluation
@@ -380,8 +381,8 @@ def find_second_dwell(date, dwell1_state, dwell2_state, t_dwell1, msid, limit, m
     # Ensure t_dwell1 is a float, may not be necessary anymore
     t_dwell1 = np.float(t_dwell1)
 
-    opt_fun = create_opt_fun(datesecs, dwell1_state, dwell2_state, t_dwell1, msid, model_spec, init,
-                             t_backoff, duration)
+    opt_fun = create_opt_fun(datesecs, dwell1_state, dwell2_state, t_dwell1, msid, model_spec, init, t_backoff,
+                             duration)
 
     # First just check the bounds to avoid unnecessary runs of `opt_fun`
     output = np.array([opt_fun(t) for t in [1.0e-6, max_dwell]],
@@ -389,156 +390,31 @@ def find_second_dwell(date, dwell1_state, dwell2_state, t_dwell1, msid, limit, m
 
     if 'max' in limit_type:
 
+        # All cases report temperatures entirely below the limit.
         if np.all(output['max'] < limit):
-            results['dwell_2_time'] = np.nan
-            ind = np.argmax(output['max'])
-            results['max_temp'] = output['max'][ind]
-            results['min_temp'] = output['min'][ind]
-            results['mean_temp'] = output['mean'][ind]
-            results['converged'] = False
-            results['unconverged_cold'] = True
+            results = _handle_unconverged_cold(output, results)
 
+        # All cases report temperatures entirely above the limit.
         elif np.all(output['max'] > limit):
-            results['dwell_2_time'] = np.nan
-            ind = np.argmin(output['max'])
-            results['max_temp'] = output['max'][ind]
-            results['min_temp'] = output['min'][ind]
-            results['mean_temp'] = output['mean'][ind]
-            results['converged'] = False
-            results['unconverged_hot'] = True
+            results = _handle_unconverged_hot(output, results)
 
+        # Temperatures straddle the limit, so a refined dwell 2 time is possible.
         else:
-
-            # --------------------------------------------------------------------------------------------------------------
-            n_dwells_1 = n_dwells
-            dwell2_range = np.logspace(1.0e-6, 1, n_dwells_1, endpoint=True) / n_dwells_1
-            dwell2_range = max_dwell * (dwell2_range - dwell2_range[0]) / (dwell2_range[-1] - dwell2_range[0])
-            output = np.array([opt_fun(t) for t in dwell2_range],
-                              dtype=[('duration2', np.float64), ('max', np.float64), ('mean', np.float64),
-                                     ('min', np.float64)])
-
-            output_sorted = np.sort(output, order='max') # low to high
-            ind = np.searchsorted(output_sorted['max'], limit)
-
-            if ind == 0:
-                # np.searchsorted finds the first suitable location by default, so if ind == 0, then the duration must
-                # fall at the bounded value. This is not true if ind == -1 (the last value).
-                results['max_temp'] = limit
-                results['dwell_2_time'] = output['duration2'][ind]
-                results['min_temp'] = output['min'][ind]
-                results['mean_temp'] = output['mean'][ind]
-                results['converged'] = True
-
-            else:
-                n_dwells_2 = n_dwells
-                t_bound = (output_sorted['duration2'][ind - 1], output_sorted['duration2'][ind])
-                dwell2_range = np.linspace(np.min(t_bound), np.max(t_bound), n_dwells_2, endpoint=True)
-                output = np.array([opt_fun(t) for t in dwell2_range],
-                                  dtype=[('duration2', np.float64), ('max', np.float64), ('mean', np.float64),
-                                         ('min', np.float64)])
-
-                # In rare conditions where all 'x' values are very close and 'wobble' a bit, it may not be sorted. If it
-                # is not sorted, the quadratic method will result in an error. It seems as if the linear method is more
-                # tolerant of this condition.
-                try:
-                    f_dwell_2_time = interpolate.interp1d(output['max'], output['duration2'], kind='quadratic',
-                                                          assume_sorted=False)
-                    f_min_temp = interpolate.interp1d(output['max'], output['min'], kind='quadratic',
-                                                      assume_sorted=False)
-                    f_mean_temp = interpolate.interp1d(output['max'], output['mean'], kind='quadratic',
-                                                       assume_sorted=False)
-                except ValueError:
-                    f_dwell_2_time = interpolate.interp1d(output['max'], output['duration2'], kind='linear',
-                                                          assume_sorted=False)
-                    f_min_temp = interpolate.interp1d(output['max'], output['min'], kind='linear',
-                                                      assume_sorted=False)
-                    f_mean_temp = interpolate.interp1d(output['max'], output['mean'], kind='linear',
-                                                       assume_sorted=False)
-
-                results['max_temp'] = limit
-                results['dwell_2_time'] = f_dwell_2_time(limit)
-                results['min_temp'] = f_min_temp(limit)
-                results['mean_temp'] = f_mean_temp(limit)
-
-            results['converged'] = True
+            results, output = _refine_dwell2_time('max', n_dwells, max_dwell, opt_fun, results)
 
     elif 'min' in limit_type:
 
+        # All cases report temperatures entirely below the limit.
         if np.all(output['min'] < limit):
-            results['dwell_2_time'] = np.nan
-            ind = np.argmax(output['min'])
-            results['max_temp'] = output['max'][ind]
-            results['min_temp'] = output['min'][ind]
-            results['mean_temp'] = output['mean'][ind]
-            results['converged'] = False
-            results['unconverged_cold'] = True
+            results = _handle_unconverged_cold(output, results)
 
+        # All cases report temperatures entirely above the limit.
         elif np.all(output['min'] > limit):
-            results['dwell_2_time'] = np.nan
-            ind = np.argmin(output['min'])
-            results['max_temp'] = output['max'][ind]
-            results['min_temp'] = output['min'][ind]
-            results['mean_temp'] = output['mean'][ind]
-            results['converged'] = False
-            results['unconverged_hot'] = True
+            results = _handle_unconverged_hot(output, results)
 
+        # Temperatures straddle the limit, so a refined dwell 2 time is possible.
         else:
-
-            # ----------------------------------------------------------------------------------------------------------
-            n_dwells_1 = n_dwells
-            dwell2_range = np.logspace(1.0e-6, 1, n_dwells_1, endpoint=True) / n_dwells_1
-            dwell2_range = max_dwell * (dwell2_range - dwell2_range[0]) / (dwell2_range[-1] - dwell2_range[0])
-            output = np.array([opt_fun(t) for t in dwell2_range],
-                              dtype=[('duration2', np.float64), ('max', np.float64), ('mean', np.float64),
-                                     ('min', np.float64)])
-
-            output_sorted = np.sort(output, order='min')  # low to high
-            ind = np.searchsorted(output_sorted['min'], limit)
-
-            if ind == 0:
-                # np.searchsorted finds the first suitable location by default, so if ind == 0, then the duration must
-                # fall at the bounded value. This is not true if ind == -1 (the last value).
-                results['min_temp'] = limit
-                results['dwell_2_time'] = output['duration2'][ind]
-                results['max_temp'] = output['max'][ind]
-                results['mean_temp'] = output['mean'][ind]
-                results['converged'] = True
-
-            else:
-                n_dwells_2 = n_dwells
-                t_bound = (output_sorted['duration2'][ind - 1], output_sorted['duration2'][ind])
-                dwell2_range = np.linspace(np.min(t_bound), np.max(t_bound), n_dwells_2, endpoint=True)
-                output = np.array([opt_fun(t) for t in dwell2_range],
-                                  dtype=[('duration2', np.float64), ('max', np.float64), ('mean', np.float64),
-                                         ('min', np.float64)])
-
-                # In rare conditions where all 'x' values are very close and 'wobble' a bit, it may not be sorted. If it
-                # is not sorted, the quadratic method will result in an error. It seems as if the linear method is more
-                # tolerant of this condition.
-                try:
-                    f_dwell_2_time = interpolate.interp1d(output['min'], output['duration2'], kind='quadratic',
-                                                          assume_sorted=False)
-                    f_max_temp = interpolate.interp1d(output['min'], output['max'], kind='quadratic',
-                                                      assume_sorted=False)
-                    f_mean_temp = interpolate.interp1d(output['min'], output['mean'], kind='quadratic',
-                                                       assume_sorted=False)
-
-                except ValueError:
-                    f_dwell_2_time = interpolate.interp1d(output['min'], output['duration2'], kind='linear',
-                                                          assume_sorted=False)
-                    f_max_temp = interpolate.interp1d(output['min'], output['max'], kind='linear',
-                                                      assume_sorted=False)
-                    f_mean_temp = interpolate.interp1d(output['min'], output['mean'], kind='linear',
-                                                       assume_sorted=False)
-
-                results['min_temp'] = limit
-                results['dwell_2_time'] = f_dwell_2_time(limit)
-                results['max_temp'] = f_max_temp(limit)
-                results['mean_temp'] = f_mean_temp(limit)
-
-            results['converged'] = True
-
-        # --------------------------------------------------------------------------------------------------------------
+            results, output = _refine_dwell2_time('min', n_dwells, max_dwell, opt_fun, results)
 
     if output['max'][0] > output['max'][-1]:
         results['hotter_state'] = 1
@@ -547,10 +423,151 @@ def find_second_dwell(date, dwell1_state, dwell2_state, t_dwell1, msid, limit, m
         results['hotter_state'] = 2
         results['colder_state'] = 1
 
-    if debug:
-        return results, output
+    return results
+
+
+def _handle_unconverged_hot(output, results):
+    """ Record useful information for the case where all output remains above the limit.
+
+    This is intended to be run solely by find_second_dwell(). This modifies the `results` dictionary inherited from the
+    parent function to provide information about the case that came the closest to converging.
+
+    Args:
+        output (ndarray): Numpy array of maximum, mean, and minimum temperatures for each simulation generated, within
+            the last `t_backoff` duration (e.g. the last two thirds of `duration`) for the final refinement step.
+        results (dict): Results dictionary initialized in parent function
+
+    Returns:
+        dict: Dictionary of results information
+
+    """
+
+    # You want the data for the case that is closest to the limit, in this case that is the data with the min value.
+    ind = np.argmin(output['min'])
+    results['unconverged_hot'] = True
+    results['dwell_2_time'] = np.nan
+    results['max_temp'] = output['max'][ind]
+    results['min_temp'] = output['min'][ind]
+    results['mean_temp'] = output['mean'][ind]
+    results['converged'] = False
+
+    return results
+
+
+def _handle_unconverged_cold(output, results):
+    """ Record useful information for the case where all output remains below the limit.
+
+    This is intended to be run solely by find_second_dwell(). This modifies the `results` dictionary inherited from the
+    parent function to provide information about the case that came the closest to converging.
+
+    Args:
+        output (ndarray): Numpy array of maximum, mean, and minimum temperatures for each simulation generated, within
+            the last `t_backoff` duration (e.g. the last two thirds of `duration`) for the final refinement step.
+        results (dict): Results dictionary initialized in parent function
+
+    Returns:
+        dict: Dictionary of results information
+
+    """
+
+    # You want the data for the case that is closest to the limit, in this case that is the data with the max value.
+    ind = np.argmax(output['max'])
+    results['unconverged_cold'] = True
+    results['dwell_2_time'] = np.nan
+    results['max_temp'] = output['max'][ind]
+    results['min_temp'] = output['min'][ind]
+    results['mean_temp'] = output['mean'][ind]
+    results['converged'] = False
+
+    return results
+
+
+def _refine_dwell2_time(limit_type, n_dwells, max_dwell, opt_fun, results):
+    """ Refine the required dwell time at pitch2 to balance a given fixed dwell time at pitch1.
+
+    This is intended to be run solely by find_second_dwell() to refine the amount of dwell 2 time is necessary to
+    balance the dwell 1 time. This modifies the `results` dictionary inherited from the parent function, but also
+    returns the `output` ndarray containing data from the final refinement operation.
+
+    Args:
+        limit_type (str): Type of limit, either a minimum or maximum temperature limit (needs to have 'min' or 'max' in
+            string passed to this argument
+        n_dwells (int): Number of second dwell possibilities to run (more dwells = finer resolution)
+        max_dwell (float): Maximum duration for second dwell, can be tuned to provide better results
+        opt_fun (function): Function that runs the schedule defined by dwell1_state and dwell2_state
+        results (dict): Results dictionary initialized in parent function
+
+    Returns:
+        dict: Dictionary of results information
+        ndarray: Numpy array of maximum, mean, and minimum temperatures for each simulation generated, within the last
+            `t_backoff` duration (e.g. the last two thirds of `duration`) for the final refinement step.
+
+    """
+
+    # This is the configuration for working with a max temperature limit (as opposed to a min temperature limit).
+    max_min = 'max'
+    min_max = 'min'
+
+    if 'min' in limit_type:
+        max_min = 'min'
+        min_max = 'max'
+
+    # dwell2_range defines the possible dwell 2 guesses, first defined in log space
+    dwell2_range = np.logspace(1.0e-6, 1, n_dwells, endpoint=True) / n_dwells
+    dwell2_range = max_dwell * (dwell2_range - dwell2_range[0]) / (dwell2_range[-1] - dwell2_range[0])
+
+    # Run the dwell1_state-dwell2_state schedule using the possible dwell 2 guesses
+    output = np.array([opt_fun(t) for t in dwell2_range], dtype=[('duration2', np.float64), ('max', np.float64),
+                                                                 ('mean', np.float64), ('min', np.float64)])
+
+    # Ensure the results are sorted. Although dwell2_range will be sorted, the output may not when two or more dwell
+    # times are close, where temperature oscillations from instabilities in the Xija model can cause the results to lose
+    # this order.
+    #
+    # The column that is used to sort the results also depends on the limit type.
+    output_sorted = np.sort(output, order=max_min)
+    ind = np.searchsorted(output_sorted[max_min], limit)
+
+    if ind == 0:
+        # np.searchsorted finds the first suitable location by default, so if ind == 0, then the duration must
+        # fall at the bounded value. This is not true if ind == -1 (the last value).
+        results[max_min + '_temp'] = limit
+        results['dwell_2_time'] = output['duration2'][ind]
+        results[min_max + '_temp'] = output[min_max][ind]
+        results['mean_temp'] = output['mean'][ind]
+        results['converged'] = True
+
     else:
-        return results
+        t_bound = (output_sorted['duration2'][ind - 1], output_sorted['duration2'][ind])
+        dwell2_range = np.linspace(np.min(t_bound), np.max(t_bound), n_dwells, endpoint=True)
+        output = np.array([opt_fun(t) for t in dwell2_range],
+                          dtype=[('duration2', np.float64), ('max', np.float64), ('mean', np.float64),
+                                 ('min', np.float64)])
+
+        # In rare conditions where all 'x' values are very close and 'wobble' a bit, it may not be sorted. If it
+        # is not sorted, the quadratic method will result in an error. It seems as if the linear method is more
+        # tolerant of this condition.
+        try:
+            f_dwell_2_time = interpolate.interp1d(output[max_min], output['duration2'], kind='quadratic',
+                                                  assume_sorted=False)
+            f_non_limit_temp = interpolate.interp1d(output[max_min], output[min_max], kind='quadratic',
+                                                    assume_sorted=False)
+            f_mean_temp = interpolate.interp1d(output[max_min], output['mean'], kind='quadratic', assume_sorted=False)
+        except ValueError:
+            f_dwell_2_time = interpolate.interp1d(output[max_min], output['duration2'], kind='linear',
+                                                  assume_sorted=False)
+            f_non_limit_temp = interpolate.interp1d(output[max_min], output[min_max], kind='linear',
+                                                    assume_sorted=False)
+            f_mean_temp = interpolate.interp1d(output[max_min], output['mean'], kind='linear', assume_sorted=False)
+
+        results[max_min + '_temp'] = limit
+        results['dwell_2_time'] = f_dwell_2_time(limit)
+        results['mean_temp'] = f_mean_temp(limit)
+        results[min_max + '_temp'] = f_non_limit_temp(limit)
+
+    results['converged'] = True
+
+    return results, output
 
 
 def run_state_pairs(msid, model_spec, init, limit, date, dwell_1_duration, state_pairs, state_pair_dtype,


### PR DESCRIPTION
This refactor's the dwell 2 search algorithm into separate functions for the different types of cases, simplifying the parent function and making it easier to read. Further refinements were also made to the tank characterization example, towards moving some of the reusable code in this example into the Timbre package.