### PR TITLE
Add git commit sha for better chandra_models version tracking

### DIFF
--- a/timbre/__init__.py
+++ b/timbre/__init__.py
@@ -3,9 +3,10 @@ import ska_helpers
 
 from .timbre import load_model_specs, get_local_model, c_to_f, f_to_c, setup_model, run_profile  # noqa
 from .timbre import calc_binary_schedule, create_opt_fun, find_second_dwell, run_state_pairs  # noqa
+from .timbre import load_github_model_specs, get_github_chandra_models_version_info # noqa
 from .balance import Balance, Balance1DPAMZT, Balance1DEAMZT, Balance1PDEAAT, BalanceFPTEMP_11, BalanceAACCCDPT  # noqa
 from .balance import Balance4RT700T, BalancePFTANK2T, BalancePM1THV2T, BalancePM2THV1T, BalancePLINE04T  # noqa
-from .balance import BalancePLINE03T, Composite, get_limited_results, get_offset_results  # noqa
+from .balance import BalancePLINE03T, Composite, get_limited_results, get_offset_results   # noqa
 
 __version__ = ska_helpers.get_version(__package__)
 

--- a/timbre/tests/test_timbre.py
+++ b/timbre/tests/test_timbre.py
@@ -34,13 +34,29 @@ def test_f_to_c():
     assert c == 100.0
 
 
-# def test_get_full_dtype():
-#     """ Test boilerplate dtype generation.
-#     """
-#
-#     d = timbre.get_full_dtype({})
-#
-#     assert isinstance(np.dtype(d), np.dtype)
+def test_load_model_specs():
+    """ Test loading model specs in different ways.
+
+    This assumes that there is a chandra models directory at the path stored in `get_model_spec.REPO_PATH`.
+    """
+
+    model_specs = timbre.load_model_specs()
+
+    keys = model_specs.keys()
+    assert 'aacccdpt' in keys
+    assert len(str(model_specs['aacccdpt'])) > 100
+    assert 'aacccdpt_md5' in keys
+    assert len(str(model_specs['aacccdpt_md5'])) == 32
+    assert 'sha' in keys
+    assert len(str(model_specs['sha'])) == 40
+    assert 'version' in keys
+    assert 'modified' in keys
+
+    version = model_specs['version']
+    sha = model_specs['sha']
+
+    # Print for use with the -s pytest flag, when desired.
+    print(f'Selected Chandra Models version {version}, with a latest commit sha of {sha}.')
 
 
 def test_setup_model():


### PR DESCRIPTION
This updates the `load_model_specs()` function to default to using a local chandra_models repository instead of a Github hosted chandra_models repository. A separate function, `load_github_model_specs()` was added so users can continue to use a Github hosted repository if needed. Both of these functions calculate and supply the md5 hash for each model, and supply the latest commit sha for the version returned.