### PR TITLE
New mups

### DIFF
--- a/timbre/__init__.py
+++ b/timbre/__init__.py
@@ -6,7 +6,7 @@ from .timbre import calc_binary_schedule, create_opt_fun, find_second_dwell, run
 from .timbre import load_github_model_specs, get_github_chandra_models_version_info  # noqa
 from .balance import Balance, Balance1DPAMZT, Balance1DEAMZT, Balance1PDEAAT, BalanceFPTEMP_11, BalanceAACCCDPT  # noqa
 from .balance import Balance4RT700T, BalancePFTANK2T, BalancePM1THV2T, BalancePM2THV1T, BalancePLINE04T  # noqa
-from .balance import BalancePLINE03T, Composite, get_limited_results, get_offset_results  # noqa
+from .balance import BalancePLINE03T, Composite, get_limited_results, get_offset_results, DEFAULT_ANCHORS  # noqa
 from .run_tools import add_inputs, run_instance, run_all_permutations, process_queue
 
 __version__ = ska_helpers.get_version(__package__)

--- a/timbre/balance.py
+++ b/timbre/balance.py
@@ -288,7 +288,7 @@ class BalancePM1THV2T(Balance):
 
     def __init__(self, date, model_spec, limit, constant_conditions, margin_factor=1.0):
         self.msid = 'pm1thv2t'
-        self.model_init = {'pm1thv2t': limit, 'mups0': limit, 'mups1': limit, 'eclipse': False, }
+        self.model_init = {'pm1thv2t': limit, 'mups0': limit, 'eclipse': False, }
         self.limit_type = 'max'
 
         super().__init__(date, model_spec, limit, constant_conditions, margin_factor)
@@ -298,7 +298,7 @@ class BalancePM2THV1T(Balance):
 
     def __init__(self, date, model_spec, limit, constant_conditions, margin_factor=1.0):
         self.msid = 'pm2thv1t'
-        self.model_init = {'pm2thv1t': limit, 'mups0': limit * 10, 'eclipse': False, }
+        self.model_init = {'pm2thv1t': limit, 'mups0': limit, 'mups1': limit, 'eclipse': False, }
         self.limit_type = 'max'
 
         super().__init__(date, model_spec, limit, constant_conditions, margin_factor)

--- a/timbre/balance.py
+++ b/timbre/balance.py
@@ -10,6 +10,21 @@ from cxotime import CxoTime
 from .timbre import run_state_pairs, find_second_dwell, load_model_specs
 
 
+DEFAULT_ANCHORS = {
+    '1dpamzt': {'anchor_limited_pitch': 155, 'anchor_offset_pitch': 70},
+    '1deamzt': {'anchor_limited_pitch': 155, 'anchor_offset_pitch': 70},
+    'fptemp_11': {'anchor_limited_pitch': 170, 'anchor_offset_pitch': 70},
+    '1pdeaat': {'anchor_limited_pitch': 45, 'anchor_offset_pitch': 160},
+    'aacccdpt': {'anchor_limited_pitch': 90, 'anchor_offset_pitch': 160},
+    'pm1thv2t': {'anchor_limited_pitch': 60, 'anchor_offset_pitch': 160},
+    'pm2thv1t': {'anchor_limited_pitch': 60, 'anchor_offset_pitch': 160},
+    '4rt700t': {'anchor_limited_pitch': 90, 'anchor_offset_pitch': 160},
+    'pftank2t': {'anchor_limited_pitch': 60, 'anchor_offset_pitch': 160},
+    'pline03t': {'anchor_limited_pitch': 175, 'anchor_offset_pitch': 70},
+    'pline04t': {'anchor_limited_pitch': 175, 'anchor_offset_pitch': 70},
+}
+
+
 def get_limited_results(results, anchor_offset_pitch):
     """ Extract the limited dwell time results.
 
@@ -273,7 +288,7 @@ class BalancePM1THV2T(Balance):
 
     def __init__(self, date, model_spec, limit, constant_conditions, margin_factor=1.0):
         self.msid = 'pm1thv2t'
-        self.model_init = {'pm1thv2t': limit, 'mups0': limit, 'eclipse': False, }
+        self.model_init = {'pm1thv2t': limit, 'mups0': limit, 'mups1': limit, 'eclipse': False, }
         self.limit_type = 'max'
 
         super().__init__(date, model_spec, limit, constant_conditions, margin_factor)
@@ -376,19 +391,7 @@ class Composite(object):
         self.model_specs = model_specs
 
         if anchors is None:
-            self.anchors = {
-                '1dpamzt': {'anchor_limited_pitch': 155, 'anchor_offset_pitch': 70},
-                '1deamzt': {'anchor_limited_pitch': 155, 'anchor_offset_pitch': 70},
-                'fptemp_11': {'anchor_limited_pitch': 170, 'anchor_offset_pitch': 70},
-                '1pdeaat': {'anchor_limited_pitch': 45, 'anchor_offset_pitch': 160},
-                'aacccdpt': {'anchor_limited_pitch': 90, 'anchor_offset_pitch': 160},
-                'pm1thv2t': {'anchor_limited_pitch': 60, 'anchor_offset_pitch': 160},
-                'pm2thv1t': {'anchor_limited_pitch': 60, 'anchor_offset_pitch': 160},
-                '4rt700t': {'anchor_limited_pitch': 90, 'anchor_offset_pitch': 160},
-                'pftank2t': {'anchor_limited_pitch': 60, 'anchor_offset_pitch': 160},
-                'pline03t': {'anchor_limited_pitch': 175, 'anchor_offset_pitch': 70},
-                'pline04t': {'anchor_limited_pitch': 175, 'anchor_offset_pitch': 70},
-            }
+            self.anchors = DEFAULT_ANCHORS
         else:
             self.anchors = anchors
 

--- a/timbre/timbre.py
+++ b/timbre/timbre.py
@@ -20,7 +20,7 @@ non_state_names = {'aacccdpt': ['aca0', ],
                    'pline03t': ['pline03t0', ],
                    'pline04t': ['pline04t0', ],
                    'pm1thv2t': ['mups0', ],
-                   'pm2thv1t': ['mups0', ],
+                   'pm2thv1t': ['mups0', 'mups1'],
                    '1deamzt': ['dea0', ],
                    '1dpamzt': ['dpa0', ],
                    'fptemp_11': ['fptemp', '1cbat', 'sim_px'],
@@ -30,7 +30,7 @@ non_state_names = {'aacccdpt': ['aca0', ],
 def get_github_chandra_models_version_info():
     """ Download a list of all tags and branches, along with associated information.
 
-    :return: Dictionrary of all tags and branches, along with associated information.
+    :return: Dictionary of all tags and branches, along with associated information.
     :rtype: dict
     """
     with urlopen('https://api.github.com/repos/sot/chandra_models/tags') as url:
@@ -94,7 +94,7 @@ def load_github_model_specs(version='master'):
         'pline03t': '/chandra_models/xija/pline/pline03t_model_spec.json',
         'pline04t': '/chandra_models/xija/pline/pline04t_model_spec.json',
         'pm1thv2t': '/chandra_models/xija/mups_valve/pm1thv2t_spec.json',
-        'pm2thv1t': '/chandra_models/xija/mups_valve/pm2thv1t_spec.json',
+        'pm2thv1t': '/chandra_models/xija/mups_valve/pm2thv1t_spec_matlab.json',
     }
 
     all_versions_info = get_github_chandra_models_version_info()
@@ -166,7 +166,7 @@ def load_model_specs(version=None, local_repository_location=None):
         'pline03t': 'chandra_models/xija/pline/pline03t_model_spec.json',
         'pline04t': 'chandra_models/xija/pline/pline04t_model_spec.json',
         'pm1thv2t': 'chandra_models/xija/mups_valve/pm1thv2t_spec.json',
-        'pm2thv1t': 'chandra_models/xija/mups_valve/pm2thv1t_spec.json',
+        'pm2thv1t': 'chandra_models/xija/mups_valve/pm2thv1t_spec_matlab.json',
     }
 
     if local_repository_location is None:


### PR DESCRIPTION
This PR makes the following changes:

- Uses new MUPS2A xija model `pm2thv1t_spec_matlab.json`
- Moves the definition of the default anchors used to generate the composite maximum dwell data, outside of the `Composite` class for easier access by outside methods

The following files are changed:
 - \_\_init\_\_.py
 - timbre.py
 - balance.py
