### PR TITLE
Switch to new ACIS FP model using *_matlab.json filename

### DIFF
--- a/timbre/balance.py
+++ b/timbre/balance.py
@@ -319,7 +319,8 @@ class BalanceFPTEMP_11(Balance):
         self.model_init = {'fptemp': limit, '1cbat': -55.0, 'sim_px': 110.0, 'eclipse': False, 'dpa_power': 0.0,
                            'orbitephem0_x': 125000e3, 'orbitephem0_y': 125000e3, 'orbitephem0_z': 125000e3,
                            'solarephem0_x': 2.6e10, 'solarephem0_y': -1.3e11, 'solarephem0_z': -5.7e10,
-                           'aoattqt1': 0.0, 'aoattqt2': 0.0, 'aoattqt3': 0.0, 'aoattqt4': 1.0, 'dh_heater': False}
+                           'aoattqt1': 0.0, 'aoattqt2': 0.0, 'aoattqt3': 0.0, 'aoattqt4': 1.0, 'dh_heater': False,
+                           '215pcast_off': False}
         self.limit_type = 'max'
 
         super().__init__(date, model_spec, limit, constant_conditions, margin_factor, maneuvers=maneuvers)

--- a/timbre/timbre.py
+++ b/timbre/timbre.py
@@ -33,7 +33,7 @@ MODEL_LOCATIONS = {
     'aacccdpt': 'chandra_models/xija/aca/aca_spec.json',
     '1deamzt': 'chandra_models/xija/dea/dea_spec.json',
     '1dpamzt': 'chandra_models/xija/dpa/dpa_spec.json',
-    'fptemp': 'chandra_models/xija/acisfp/acisfp_spec.json',
+    'fptemp': 'chandra_models/xija/acisfp/acisfp_spec_matlab.json',
     '1pdeaat': 'chandra_models/xija/psmc/psmc_spec.json',
     'pftank2t': 'chandra_models/xija/pftank2t/pftank2t_spec.json',
     '4rt700t': 'chandra_models/xija/fwdblkhd/4rt700t_spec.json',


### PR DESCRIPTION
This uses the new acisfp model that uses the `215pcast` MSID state to control an additional power input.