### PR TITLE
Fix fptemp non state name key, fix hrc output header line

### DIFF
--- a/timbre/run_tools.py
+++ b/timbre/run_tools.py
@@ -643,7 +643,7 @@ def _worker_hrc(arg, q):
                           limited_matches_offset=False, imaging_detector=imaging_detector,
                           spectroscopy_detector=spectroscopy_detector)
 
-    header = ','.join(res.columns)
+    header = ','.join(res.columns) + '\n'
     res = res.to_csv(index=False, header=False)
     q.put((res, header))
 

--- a/timbre/timbre.py
+++ b/timbre/timbre.py
@@ -27,7 +27,7 @@ NON_STATE_NAMES = {'aacccdpt': ['aca0', ],
                    'pm2thv1t': ['mups0', 'mups1'],
                    '1deamzt': ['dea0', ],
                    '1dpamzt': ['dpa0', ],
-                   'fptemp_11': ['fptemp', '1cbat', 'sim_px'],
+                   'fptemp': ['fptemp', '1cbat', 'sim_px'],
                    '1pdeaat': ['pin1at', ],
                    '2ceahvpt': ['cea0', 'cea1']}
 


### PR DESCRIPTION
Looks like the RW5 model snuck in with another PR. This PR simply updates the fptemp non state name key and adds a newline to the header in the HRC post processing analysis output.